### PR TITLE
Fix Italian translation typo

### DIFF
--- a/translations/it.json
+++ b/translations/it.json
@@ -44,7 +44,7 @@
     "showLangMenu": "Cambia Lingua",
     "legend_guidance_text": "Seleziona le categorie per mostrarle/nasconderle sulla mappa.",
     "selectAll" : "Seleziona Tutto",
-    "deselectAll" : "Deselezionza Tutto",
+    "deselectAll" : "Deseleziona Tutto",
     "zoomIn": "Ingrandisci",
     "zoomOut": "Riduci",
     "youAreHere": "Sei qui!",


### PR DESCRIPTION
## Summary
- fix typo in Italian translations file

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f456daf0c83249efe10f69660df97